### PR TITLE
Update the credit example on README.md so that it works as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ clockwork.getBalance(function(error, credit) {
     if (error) {
     	console.log('Something went wrong', error);
 	} else {
-		console.log('Your balance',resp);
+		console.log('Your balance',credit);
 	}
 });
 ```


### PR DESCRIPTION
I've updated the README.md with a minor change to fix an issue with the example of how to query credit.

Previously it suggested outputting the contents of 'resp' however the actual variable is 'credit' therefore it would error out.

Have verified behaviour against the latest version of clockwork for node.
